### PR TITLE
new flowables and primary contexts from ecoinvent3.10

### DIFF
--- a/fedelemflowlist/input/ChemicalsFlowablePrimaryContexts.csv
+++ b/fedelemflowlist/input/ChemicalsFlowablePrimaryContexts.csv
@@ -10048,6 +10048,7 @@ Uranyl(III),Emission,Water
 "Heptane, 2,4-dimethyl-",Emission,Air
 "Heptane, 2,5-dimethyl-",Emission,Air
 "Octane, 3-methyl-",Emission,Air
+Aluminum(III),Emission,Air
 Aluminum(III),Emission,Ground
 Aluminum(III),Emission,Water
 Bendiocarb phenol,Emission,Ground
@@ -11634,13 +11635,18 @@ Protactinium-234,Emission,Water
 Praseodymium-147,Emission,Air
 Praseodymium,Resource,Ground
 Krypton-89,Emission,Air
+Potassium(I),Emission,Air
+Potassium(I),Emission,Ground
 Potassium(I),Emission,Water
 Nickel(III),Emission,Water
 Nickel(II),Emission,Air
 Nickel(II),Emission,Ground
 Nickel(II),Emission,Water
+Sodium(I),Emission,Air
+Sodium(I),Emission,Ground
 Sodium(I),Emission,Water
 Manganese(III),Emission,Water
+Calcium(II),Emission,Air
 Calcium(II),Emission,Ground
 Calcium(II),Emission,Water
 Cadmium(II),Emission,Air
@@ -11649,6 +11655,8 @@ Cadmium(II),Emission,Water
 Lead(II),Emission,Air
 Lead(II),Emission,Ground
 Lead(II),Emission,Water
+Manganese(II),Emission,Air
+Manganese(II),Emission,Ground
 Manganese(II),Emission,Water
 "Glyphosate, ammonium salt",Emission,Air
 "Glyphosate, ammonium salt",Emission,Ground
@@ -11657,6 +11665,8 @@ Iodosulfuron-methyl,Emission,Ground
 Vanadium(III),Emission,Air
 Vanadium(III),Emission,Ground
 Vanadium(III),Emission,Water
+Lithium(I),Emission,Air
+Lithium(I),Emission,Ground
 Lithium(I),Emission,Water
 Copper(I),Emission,Water
 Copper(I),Emission,Ground
@@ -15003,3 +15013,23 @@ Allyl 2-hydroxyisobutyrate,Emission,Ground
 "8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene",Emission,Water
 "8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene",Emission,Air
 "8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene",Emission,Ground
+Palladium(II),Emission,Air
+Palladium(II),Emission,Water
+Palladium(II),Emission,Ground
+Titanium(II),Emission,Air
+Titanium(II),Emission,Water
+Titanium(II),Emission,Ground
+Titanium(IV),Emission,Air
+Titanium(IV),Emission,Water
+Titanium(IV),Emission,Ground
+Rhodium(III),Emission,Air
+Phenyltin,Emission,Water
+Potassium dihydrogen phosphite,Emission,Ground
+Mefentrifluconazole,Emission,Ground
+Sulfur dichloride,Emission,Air
+Sulfur dichloride,Emission,Water
+Sodium methoxide,Emission,Water
+Thionyl chloride,Emission,Air
+Strontium(II),Emission,Air
+Strontium(II),Emission,Ground
+Strontium(II),Emission,Water

--- a/fedelemflowlist/input/ChemicalsFlowablePrimaryContexts.csv
+++ b/fedelemflowlist/input/ChemicalsFlowablePrimaryContexts.csv
@@ -9515,6 +9515,7 @@ Sulfur trioxide,Emission,Air
 6-Nitrochrysene,Emission,Air
 Cobalt carbonate,Emission,Air
 Phosphorus trichloride,Emission,Air
+Phosphorus trichloride,Emission,Water
 Potassium bromate,Emission,Air
 Sodium chromate(VI),Emission,Air
 Hydrogen selenide,Emission,Air
@@ -11434,6 +11435,7 @@ Tin oxide,Emission,Air
 Triazamate,Emission,Ground
 "1,2,4-Benzotriazine, 7-chloro-3-(1H-imidazol-1-yl)-, 1-oxide",Emission,Ground
 Triphenyltin,Emission,Ground
+Triphenyltin,Emission,Water
 Trichlorosilane,Emission,Air
 Trichlorosilane,Emission,Water
 Triticonazole,Emission,Ground
@@ -15033,3 +15035,17 @@ Thionyl chloride,Emission,Air
 Strontium(II),Emission,Air
 Strontium(II),Emission,Ground
 Strontium(II),Emission,Water
+Pydiflumetofen,Emission,Air
+Pydiflumetofen,Emission,Ground
+Phosphorus pentachloride,Emission,Water
+Penflufen,Emission,Ground
+Penflufen,Emission,Water
+Monobutyltin(III),Emission,Water
+Diphenyltin,Emission,Water
+Dimethyldichlorosilane,Emission,Air
+Dimethyldichlorosilane,Emission,Water
+Diflufenzopyr,Emission,Air
+Diflufenzopyr,Emission,Water
+Dibutyltin,Emission,Water
+Ammonium sulfate,Emission,Water
+Octaethylene glycol monododecyl ether,Emission,Air

--- a/fedelemflowlist/input/ChemicalsFlowables.csv
+++ b/fedelemflowlist/input/ChemicalsFlowables.csv
@@ -5809,3 +5809,13 @@ Sulfur dichloride,10545-99-0,SCL2,,kg,https://pubchem.ncbi.nlm.nih.gov/compound/
 Sodium methoxide,124-41-4,CH3ONa,Sodium methanolate,kg,https://pubchem.ncbi.nlm.nih.gov/compound/10942334,0
 Thionyl chloride,7719-09-7,SOCL2,,kg,https://pubchem.ncbi.nlm.nih.gov/compound/24386,0
 Strontium(II),22537-39-9,Sr+2,"Strontium cation;Strontium, ion",kg,https://pubchem.ncbi.nlm.nih.gov/compound/Strontium-cation,0
+Pydiflumetofen,1228284-64-7,C16H16Cl3F2N3O2,"3-(Difluoromethyl)-N-methoxy-1-methyl-N-(1-methyl-2-(2,4,6-trichlorophenyl)ethyl)-1H-pyrazole-4-carboxamide",kg,https://pubchem.ncbi.nlm.nih.gov/compound/56933411,0
+Phosphorus pentachloride,10026-13-8,Cl5P,pentachloro-lambda5-phosphane,kg,https://pubchem.ncbi.nlm.nih.gov/compound/24819,0
+Penflufen,494793-67-8,C18H24FN3O,"5-fluoro-1,3-dimethyl-N-[2-(4-methylpentan-2-yl)phenyl]pyrazole-4-carboxamide",kg,https://pubchem.ncbi.nlm.nih.gov/compound/11674113,0
+Monobutyltin(III),78763-54-9,C4H9Sn+3,Butyltin(3+) Monobutyltin,kg,https://pubchem.ncbi.nlm.nih.gov/compound/54267,0
+Diphenyltin,1011-95-6,C12H12Sn,,kg,https://pubchem.ncbi.nlm.nih.gov/compound/70535,0
+Dimethyldichlorosilane,75-78-5,C2H6Cl2Si,Dichloro(dimethyl)silane,kg,https://pubchem.ncbi.nlm.nih.gov/compound/6398,0
+Diflufenzopyr,109293-97-2,C15H12F2N4O3,,kg,https://pubchem.ncbi.nlm.nih.gov/compound/6125184,0
+Dibutyltin,1002-53-5,C8H18Sn,,kg,https://pubchem.ncbi.nlm.nih.gov/compound/6484,0
+Ammonium sulfate,7783-20-2,H8N2O4S,diammonium sulfate diazanium,kg,https://pubchem.ncbi.nlm.nih.gov/compound/6097028,0
+Octaethylene glycol monododecyl ether,3055-98-9,C28H58O9,,kg,https://pubchem.ncbi.nlm.nih.gov/compound/123921,0

--- a/fedelemflowlist/input/ChemicalsFlowables.csv
+++ b/fedelemflowlist/input/ChemicalsFlowables.csv
@@ -5798,3 +5798,14 @@ Allyl 2-hydroxyisobutyrate,19444-21-4,,,kg,https://echa.europa.eu/substance-info
 "2-Butene, 1,1,4,4-tetramethoxy-",5370-08-1,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.139.336,0
 "Phenol, 4,5-dimethyl-2-(1-methylethyl)-",35786-94-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.214.943,0
 "8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene",38233-76-0,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.149.349,0
+Palladium(II),16065-88-6,Pd2+,Palladium ion,kg,https://glossary.ecoinvent.org/ids/ff888538-eda9-4bf7-8612-a75acf1e85ac,0
+Titanium(II),15969-58-1,Ti,Ti2+,kg,https://pubchem.ncbi.nlm.nih.gov/compound/177711,0
+Titanium(IV),16043-45-1,Ti,Ti4+,kg,https://pubchem.ncbi.nlm.nih.gov/compound/114942,0
+Rhodium(III),16065-89-7,Rh,Rhodium ion,kg,,0
+Phenyltin,2406-68-0,,"Stannane, phenyl-",kg,https://pubchem.ncbi.nlm.nih.gov/compound/6335496,0
+Potassium dihydrogen phosphite,13977-65-6,H3O3P.K,"Monopotassium phosphite; Phosphonic acid, potassium salt (1:1); Phosphonic acid, monopotassium salt",kg,https://commonchemistry.cas.org/detail?cas_rn=13977-65-6,0
+Mefentrifluconazole,1417782-03-6,C18H15ClF3N3O2,"2-[4-(4-Chlorophenoxy)-2-(trifluoromethyl)phenyl]-1-(1,2,4-triazol-1-yl)propan-2-ol",kg,https://pubchem.ncbi.nlm.nih.gov/compound/71230671,0
+Sulfur dichloride,10545-99-0,SCL2,,kg,https://pubchem.ncbi.nlm.nih.gov/compound/25353,0
+Sodium methoxide,124-41-4,CH3ONa,Sodium methanolate,kg,https://pubchem.ncbi.nlm.nih.gov/compound/10942334,0
+Thionyl chloride,7719-09-7,SOCL2,,kg,https://pubchem.ncbi.nlm.nih.gov/compound/24386,0
+Strontium(II),22537-39-9,Sr+2,"Strontium cation;Strontium, ion",kg,https://pubchem.ncbi.nlm.nih.gov/compound/Strontium-cation,0

--- a/fedelemflowlist/input/GroupsFlowablePrimaryContexts.csv
+++ b/fedelemflowlist/input/GroupsFlowablePrimaryContexts.csv
@@ -304,6 +304,7 @@ Oxygenated compounds,Emission,Air
 "Paraffin, C7",Emission,Air
 "Paraffin, C8",Emission,Air
 "Paraffin, C9",Emission,Air
+Pesticides,Emission,Air
 Pesticides,Emission,Ground
 Pesticides,Emission,Water
 "Pesticides, chlorinated",Emission,Ground

--- a/fedelemflowlist/input/GroupsFlowablePrimaryContexts.csv
+++ b/fedelemflowlist/input/GroupsFlowablePrimaryContexts.csv
@@ -351,6 +351,7 @@ Silanes,Emission,Air
 Silver compounds,Emission,Air
 Silver compounds,Emission,Ground
 Silver compounds,Emission,Water
+Surfactants,Emission,Air
 Surfactants,Emission,Ground
 Surfactants,Emission,Water
 "Suspended solids, inorganic",Emission,Ground


### PR DESCRIPTION
Ecoinvent 3.10 introduces several new flowables and primary contexts that cannot be mapped to FEDEFL at the moment. This PR addresses this issue.

New flowables:
Flowable | Primary contexts | CAS No | Formula | Synonyms | Unit | External Ref 
--- | --- | --- | --- | --- | --- | ---
Palladium(II)  | emission air/water/ground | 016065-88-6 | Pd+2 | Palladium ion | kg | https://glossary.ecoinvent.org/ids/ff888538-eda9-4bf7-8612-a75acf1e85ac | no
Titanium(II) | emission air/water/ground | 15969-58-1 | Ti | Ti2+ | kg | https://pubchem.ncbi.nlm.nih.gov/compound/177711 | no
Titanium(IV)  | emission air/water/ground | 16043-45-1 | Ti | Ti4+ | kg | https://pubchem.ncbi.nlm.nih.gov/compound/114942  | no
Rhodium(III) | emission air | 016065-89-7 | Rh+3 | Rhodium ion | kg | | no
Phenyltin  | emission/water | 2406-68-0 | | Stannane, phenyl- | kg | https://pubchem.ncbi.nlm.nih.gov/compound/6335496 | no
Potassium dihydrogen phosphite | emission/ground | 13977-65-6 | H3O3P.K | Monopotassium phosphite; Phosphonic acid, potassium salt (1:1); Phosphonic acid, monopotassium salt | kg | https://commonchemistry.cas.org/detail?cas_rn=13977-65-6 | no
Mefentrifluconazole  | emission/ground | 1417782-03-6 | C18H15ClF3N3O2 | 2-[4-(4-Chlorophenoxy)-2-(trifluoromethyl)phenyl]-1-(1,2,4-triazol-1-yl)propan-2-ol | kg | https://pubchem.ncbi.nlm.nih.gov/compound/71230671
Sulfur dichloride | emission/air emision/water | 10545-99-0 | SCL2 | | kg | https://pubchem.ncbi.nlm.nih.gov/compound/25353
Sodium methoxide | emission/water | 124-41-4 | CH3ONa | Sodium methanolate | kg | https://pubchem.ncbi.nlm.nih.gov/compound/10942334
Thionyl chloride | emission/air | 7719-09-7 | SOCL2 | | kg | https://pubchem.ncbi.nlm.nih.gov/compound/24386
Strontium(II) | emission/water ground air | 22537-39-9 | Sr+2 | Strontium cation;Strontium, ion | kg | https://pubchem.ncbi.nlm.nih.gov/compound/Strontium-cation,0

And new primary contexts for existing flowables:
```
Aluminum(III) | emission/air
Potassium(I) | emission/air emission/ground
Lithium(I) | emission/ground emission/air
Sodium(I) | emission/ground emission/air
Manganese(II) | emission/ground emission/air
Calcium(II) emission/air
Pesticides emission/air
```

In an upcoming PR I will also address older ecoinvent flowables not in FEDEFL (flowables that were introduced in ecoinvent<=3.9.1 and which are still not in FEDEFL)

@ErCollao @ganorris